### PR TITLE
disable async log temporally

### DIFF
--- a/client/utils/log.c
+++ b/client/utils/log.c
@@ -15,7 +15,7 @@
 #include "../init.h"
 #include "utils.h"
 
-#define ASYNC_LOG 1
+#define ASYNC_LOG 0
 
 //#define LOG_PRINT // print log to stdout
 


### PR DESCRIPTION
disable async log temporally due to different behavior between different OS, try to replace with another solution soon.