### PR TITLE
Worker names

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -868,9 +868,9 @@ int xdag_create_block(struct xdag_field *fields, int inputsCount, int outputsCou
 	res = xdag_add_block(block);
 	if (res > 0) {
 		if (mining) {
-			memcpy(g_xdag_mined_hashes[MAIN_TIME(send_time) & (XDAG_POOL_CONFIRMATIONS_COUNT - 1)],
+			memcpy(g_xdag_mined_hashes[MAIN_TIME(send_time) & (CONFIRMATIONS_COUNT - 1)],
                 newBlockHash, sizeof(xdag_hash_t));
-			memcpy(g_xdag_mined_nonce[MAIN_TIME(send_time) & (XDAG_POOL_CONFIRMATIONS_COUNT - 1)],
+			memcpy(g_xdag_mined_nonce[MAIN_TIME(send_time) & (CONFIRMATIONS_COUNT - 1)],
                 block[0].field[XDAG_BLOCK_FIELDS - 1].data, sizeof(xdag_hash_t));
 		}
 

--- a/client/commands.c
+++ b/client/commands.c
@@ -664,7 +664,7 @@ int xfer_callback(void *data, xdag_hash_t hash, xdag_amount_t amount, xdag_time_
 	if(!amount) {
 		return -1;
 	}
-	if(!g_is_miner && xdag_main_time() < (time >> 16) + 2 * XDAG_POOL_CONFIRMATIONS_COUNT) {
+	if(!g_is_miner && xdag_main_time() < (time >> 16) + 2 * CONFIRMATIONS_COUNT) {
 		return 0;
 	}
 	for(i = 0; i < xferData->keysCount; ++i) {

--- a/client/miner.c
+++ b/client/miner.c
@@ -27,7 +27,6 @@
 #define MINERS_PWD             "minersgonnamine"
 #define SECTOR0_BASE           0x1947f3acu
 #define SECTOR0_OFFSET         0x82e9d1b5u
-#define HEADER_WORD            0x3fca9e2bu
 #define SEND_PERIOD            10                                  /* share period of sending shares */
 
 struct miner {
@@ -94,7 +93,7 @@ static int send_to_pool(struct xdag_field *fld, int nfld)
 
 		xdag_hash(f, sizeof(struct xdag_block), h);
 
-		f[0].transport_header = HEADER_WORD;
+		f[0].transport_header = BLOCK_HEADER_WORD;
 
 		uint32_t crc = crc_of_array((uint8_t*)f, sizeof(struct xdag_block));
 

--- a/client/mining_common.h
+++ b/client/mining_common.h
@@ -13,7 +13,8 @@
 #include <poll.h>
 #endif
 
-#define DATA_SIZE     (sizeof(struct xdag_field) / sizeof(uint32_t))
+#define DATA_SIZE          (sizeof(struct xdag_field) / sizeof(uint32_t))
+#define BLOCK_HEADER_WORD  0x3fca9e2bu
 
 struct xdag_pool_task {
 	struct xdag_field task[2], lastfield, minhash, nonce;

--- a/client/pool.c
+++ b/client/pool.c
@@ -34,7 +34,6 @@
 #define START_MINERS_COUNT     256
 #define START_MINERS_IP_COUNT  8
 
-#define HEADER_WORD                        0x3fca9e2bu
 #define FUND_ADDRESS                       "FQglVQtb60vQv2DOWEUL7yh3smtj7g1s" /* community fund */
 #define SHARES_PER_TASK_LIMIT              20                                 /* maximum count of shares per task */
 #define DEFAUL_CONNECTIONS_PER_MINER_LIMIT 100
@@ -651,7 +650,6 @@ static int register_new_miner(connection_list_element *connection)
 		pthread_mutex_unlock(&g_descriptors_mutex);
 	}
 
-
 	return 1;
 }
 
@@ -684,6 +682,104 @@ static int share_can_be_accepted(struct miner_pool_data *miner, xdag_hash_t shar
 	return 1;
 }
 
+// checks if received data belongs to block and processes that block
+// returns:
+// -1 - error
+// 0 - received data does not belong to block
+// 1 - block data is processed
+static int is_block_data_received(connection_list_element *connection)
+{
+	struct connection_pool_data *conn_data = &connection->connection_data;
+
+	if(!conn_data->block_size && conn_data->data[0] == BLOCK_HEADER_WORD) {
+		conn_data->block = malloc(sizeof(struct xdag_block));
+
+		if(!conn_data->block) {
+			return -1;
+		}
+
+		memcpy(conn_data->block->field, conn_data->data, sizeof(struct xdag_field));
+		conn_data->block_size++;
+	} else if(conn_data->nfield_in == 1) {
+		close_connection(connection, "protocol mismatch");
+		return -1;
+	} else if(conn_data->block_size) {
+		memcpy(conn_data->block->field + conn_data->block_size, conn_data->data, sizeof(struct xdag_field));
+		conn_data->block_size++;
+		if(conn_data->block_size == XDAG_BLOCK_FIELDS) {
+			uint32_t crc = conn_data->block->field[0].transport_header >> 32;
+
+			conn_data->block->field[0].transport_header &= (uint64_t)0xffffffffu;
+
+			if(crc == crc_of_array((uint8_t*)conn_data->block, sizeof(struct xdag_block))) {
+				conn_data->block->field[0].transport_header = 0;
+
+				pthread_mutex_lock(&g_pool_mutex);
+
+				if(!g_firstb) {
+					g_firstb = g_lastb = conn_data->block;
+				} else {
+					g_lastb->field[0].transport_header = (uintptr_t)conn_data->block;
+					g_lastb = conn_data->block;
+				}
+
+				pthread_mutex_unlock(&g_pool_mutex);
+			} else {
+				free(conn_data->block);
+			}
+
+			conn_data->block = 0;
+			conn_data->block_size = 0;
+		}
+	} else {
+		return 0;
+	}
+
+	return 1;
+}
+
+// processes received share
+// returns:
+// 0 - error
+// 1 - success
+static int process_received_share(connection_list_element *connection)
+{
+	struct connection_pool_data *conn_data = &connection->connection_data;
+
+	const uint64_t task_index = g_xdag_pool_task_index;
+	struct xdag_pool_task *task = &g_xdag_pool_task[task_index & 1];
+
+	if(++conn_data->shares_count > SHARES_PER_TASK_LIMIT) {   //if shares count limit is exceded it is considered as spamming and current connection is disconnected
+		close_connection(connection, "Spamming of shares");
+		return 0;
+	}
+
+	if(conn_data->state == UNKNOWN_ADDRESS) {
+		if(!register_new_miner(connection)) {
+			return 0;
+		}
+	} else {
+		if(!conn_data->miner) {
+			close_connection(connection, "Miner is unregistered");
+			return 0;
+		}
+		if(memcmp(conn_data->miner->id.data, conn_data->data, sizeof(xdag_hashlow_t)) != 0) {
+			close_connection(connection, "Wallet address was unexpectedly changed");
+			return 0;
+		}
+		memcpy(conn_data->miner->id.data, conn_data->data, sizeof(struct xdag_field));	//TODO:do I need to copy whole field?
+	}
+
+	conn_data->last_share_time = time(0);
+
+	if(share_can_be_accepted(conn_data->miner, (uint64_t*)conn_data->data, task_index)) {
+		xdag_hash_t hash;
+		xdag_hash_final(task->ctx0, conn_data->data, sizeof(struct xdag_field), hash);
+		xdag_set_min_share(task, conn_data->miner->id.data, hash);
+		calculate_nopaid_shares(conn_data, task, hash);
+	}
+}
+
 static int receive_data_from_connection(connection_list_element *connection)
 {
 #if _DEBUG
@@ -707,79 +803,16 @@ static int receive_data_from_connection(connection_list_element *connection)
 		conn_data->data_size = 0;
 		dfslib_uncrypt_array(g_crypt, conn_data->data, DATA_SIZE, conn_data->nfield_in++);
 
-		if(!conn_data->block_size && conn_data->data[0] == HEADER_WORD) {
-			conn_data->block = malloc(sizeof(struct xdag_block));
-
-			if(!conn_data->block) return 0;
-
-			memcpy(conn_data->block->field, conn_data->data, sizeof(struct xdag_field));
-			conn_data->block_size++;
-		} else if(conn_data->nfield_in == 1) {
-			close_connection(connection, "protocol mismatch");
+		int result = is_block_data_received(connection);
+		if(result < 0) {
 			return 0;
-		} else if(conn_data->block_size) {
-			memcpy(conn_data->block->field + conn_data->block_size, conn_data->data, sizeof(struct xdag_field));
-			conn_data->block_size++;
-			if(conn_data->block_size == XDAG_BLOCK_FIELDS) {
-				uint32_t crc = conn_data->block->field[0].transport_header >> 32;
-
-				conn_data->block->field[0].transport_header &= (uint64_t)0xffffffffu;
-
-				if(crc == crc_of_array((uint8_t*)conn_data->block, sizeof(struct xdag_block))) {
-					conn_data->block->field[0].transport_header = 0;
-
-					pthread_mutex_lock(&g_pool_mutex);
-
-					if(!g_firstb) {
-						g_firstb = g_lastb = conn_data->block;
-					} else {
-						g_lastb->field[0].transport_header = (uintptr_t)conn_data->block;
-						g_lastb = conn_data->block;
-					}
-
-					pthread_mutex_unlock(&g_pool_mutex);
-				} else {
-					free(conn_data->block);
-				}
-
-				conn_data->block = 0;
-				conn_data->block_size = 0;
-			}
-		} else {
-			//share is received
-			const uint64_t task_index = g_xdag_pool_task_index;
-			struct xdag_pool_task *task = &g_xdag_pool_task[task_index & 1];
-
-			if(++conn_data->shares_count > SHARES_PER_TASK_LIMIT) {   //if shares count limit is exceded it is considered as spamming and current connection is disconnected
-				close_connection(connection, "Spamming of shares");
-				return 0;
-			}
-
-			if(conn_data->state == UNKNOWN_ADDRESS) {
-				if(!register_new_miner(connection)) {
-					return 0;
-				}
-			} else {
-				if(!conn_data->miner) {
-					close_connection(connection, "Miner is unregistered");
-					return 0;
-				}
-				if(memcmp(conn_data->miner->id.data, conn_data->data, sizeof(xdag_hashlow_t)) != 0) {
-					close_connection(connection, "Wallet address was unexpectedly changed");
-					return 0;
-				}
-				memcpy(conn_data->miner->id.data, conn_data->data, sizeof(struct xdag_field));	//TODO:do I need to copy whole field?
-			}
-
-			conn_data->last_share_time = time(0);
-
-			if(share_can_be_accepted(conn_data->miner, (uint64_t*)conn_data->data, task_index)) {
-				xdag_hash_t hash;
-				xdag_hash_final(task->ctx0, conn_data->data, sizeof(struct xdag_field), hash);
-				xdag_set_min_share(task, conn_data->miner->id.data, hash);
-				calculate_nopaid_shares(conn_data, task, hash);
-			}
+		}		
+		if(result > 0) {
+			return 1;
 		}
+		
+		//share is received
+		process_received_share(connection);
 	}
 
 	return 1;
@@ -1025,7 +1058,7 @@ static double countpay(struct miner_pool_data *miner, int confirmation_index, do
 	int diff_count = 0;
 
 	//if miner is in archive state and last connection was disconnected more than 16 minutes ago we pay for the rest of shares and clear shares
-	if(miner->state == MINER_ARCHIVE && g_xdag_pool_task_index - miner->task_index > XDAG_POOL_CONFIRMATIONS_COUNT) {
+	if(miner->state == MINER_ARCHIVE && g_xdag_pool_task_index - miner->task_index > CONFIRMATIONS_COUNT) {
 		sum += process_outdated_miner(miner);
 		diff_count++;
 	} else if(miner->maxdiff[confirmation_index] > 0) {
@@ -1275,7 +1308,7 @@ static int print_miner(FILE *out, int index, struct miner_pool_data *miner, int 
 
 	if(print_connections) {
 		connection_list_element *elt;
-		int index = 0;
+		int conn_index = 0;
 		LL_FOREACH(g_connection_list_head, elt)
 		{
 			if(elt->connection_data.miner == miner) {
@@ -1285,7 +1318,7 @@ static int print_miner(FILE *out, int index, struct miner_pool_data *miner, int 
 				sprintf(in_out_str, "%llu/%llu", (unsigned long long)conn_data->nfield_in * sizeof(struct xdag_field),
 					(unsigned long long)conn_data->nfield_out * sizeof(struct xdag_field));
 
-				fprintf(out, " C%d. -                                 -        %-21s  %-16s  %lf\n", ++index,
+				fprintf(out, " C%d. -                                 -        %-21s  %-16s  %lf\n", ++conn_index,
 					ip_port_str, in_out_str, connection_calculate_unpaid_shares(conn_data));
 			}
 		}

--- a/client/pool.h
+++ b/client/pool.h
@@ -6,8 +6,7 @@
 #include "hash.h"
 
 #define MAX_CONNECTIONS_COUNT          8192
-#define XDAG_POOL_CONFIRMATIONS_COUNT  16
-#define CONFIRMATIONS_COUNT            XDAG_POOL_CONFIRMATIONS_COUNT   /*16*/
+#define CONFIRMATIONS_COUNT            16
 
 enum disconnect_type
 {
@@ -16,8 +15,8 @@ enum disconnect_type
 	DISCONNECT_ALL = 3
 };
 
-extern xdag_hash_t g_xdag_mined_hashes[XDAG_POOL_CONFIRMATIONS_COUNT];
-extern xdag_hash_t g_xdag_mined_nonce[XDAG_POOL_CONFIRMATIONS_COUNT];
+extern xdag_hash_t g_xdag_mined_hashes[CONFIRMATIONS_COUNT];
+extern xdag_hash_t g_xdag_mined_nonce[CONFIRMATIONS_COUNT];
 
 /* initialization of the pool */
 extern int xdag_initialize_pool(const char *pool_arg);


### PR DESCRIPTION
```xdag> miners
List of miners:
 NN  Address for payment to            Status   IP and port            in/out bytes     nopaid shares   worker name
-------------------------------------------------------------------------------------------------------------------
 -1. 4sQ1JEZ5i7r1/voTfUFs7esRxm9u2zz8  fee      -                      -                 0.000000       -
  0. 5hXQ/W6ysNRX0SMN+pC2lpTX/g65PPbr  active   -                      -                 0.000000       -
 C1. -                                 -        127.0.0.1:49304        640/832           0.000000       -
  1. ZO03FGsAsWfTroIQiH3hbOhrSGDENlM6  active   -                      -                 210.030379     -
 C1. -                                 -        127.0.0.1:49368        768/768           143.907851     GpuW1
 C2. -                                 -        127.0.0.1:49445        832/640           127.309959     GpuW2
-------------------------------------------------------------------------------------------------------------------
Total 2 active miners.
```
32 packet with worker name can sent after the first block. Miner which does not send worker name is supported. 
But GPU miner which sends worker name is compatible only with xdag 0.2.5+