### PR TITLE
Crash in case of disconnection

### DIFF
--- a/client/miner.c
+++ b/client/miner.c
@@ -306,7 +306,7 @@ begin:
 	return 0;
 
 err:
-	xdag_err("Miner : %s %s (error %d)", mess, res);
+	xdag_err("Miner: %s (error %d)", mess, res);
 
 	pthread_mutex_lock(&g_miner_mutex);
 


### PR DESCRIPTION
Bug with crash of miner in case of disconnection is fixed.

One parameter from that function call earlier, but format string was not updated. So now wallet crashes if connection to pool is lost