### PR TITLE
SIGPOLL is deprecated

### DIFF
--- a/client/statsdaemon.c
+++ b/client/statsdaemon.c
@@ -9,10 +9,6 @@
 #include <sys/un.h>
 #include <errno.h>
 
-#if defined (_MACOS) || defined (_APPLE)
-#define SIGPOLL SIGIO
-#endif
-
 #define CHEATCOIN_COMMAND_MAX	0x1000
 #define UNIX_SOCK				"unix_sock.dat"
 #define STATS_TXT				"/home/ec2-user/cheat/stats.txt"
@@ -36,7 +32,7 @@ static void daemonize(void) {
 	signal(SIGUSR1, SIG_IGN);
 	signal(SIGUSR2, SIG_IGN);
 	signal(SIGTSTP, SIG_IGN); /* ignore tty signals */
-	signal(SIGPOLL, SIG_IGN);
+	signal(SIGIO, SIG_IGN);
 	signal(SIGTTIN, SIG_IGN);
 	signal(SIGTTOU, SIG_IGN);
 	signal(SIGVTALRM, SIG_IGN);

--- a/dnet/dnet_xdag.c
+++ b/dnet/dnet_xdag.c
@@ -41,10 +41,6 @@
 #include "dnet_packet.h"
 #include "dnet_history.h"
 
-#if defined (__MACOS__) || defined (__APPLE__)
-#define SIGPOLL SIGIO
-#endif
-
 #define SECTOR_SIZE			0x200
 #define MAX_CONNECTIONS_PER_THREAD	0x1000
 #define DEF_NTHREADS			6
@@ -509,7 +505,7 @@ static void daemonize(void) {
 	signal(SIGUSR1, SIG_IGN);
 	signal(SIGUSR2, SIG_IGN);
 	signal(SIGTSTP, SIG_IGN); /* ignore tty signals */
-	signal(SIGPOLL, SIG_IGN);
+	signal(SIGIO, SIG_IGN);
 	signal(SIGTTIN, SIG_IGN);
 	signal(SIGTTOU, SIG_IGN);
 	signal(SIGVTALRM, SIG_IGN);


### PR DESCRIPTION
SIGPOLL is deprecated and is the same thing of SIGIO in linux
https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/signal.h

#define SIGHUP		 1
#define SIGINT		 2
#define SIGQUIT		 3
#define SIGILL		 4
#define SIGTRAP		 5
#define SIGABRT		 6
#define SIGIOT		 6
#define SIGBUS		 7
#define SIGFPE		 8
#define SIGKILL		 9
#define SIGUSR1		10
#define SIGSEGV		11
#define SIGUSR2		12
#define SIGPIPE		13
#define SIGALRM		14
#define SIGTERM		15
#define SIGSTKFLT	16
#define SIGCHLD		17
#define SIGCONT		18
#define SIGSTOP		19
#define SIGTSTP		20
#define SIGTTIN		21
#define SIGTTOU		22
#define SIGURG		23
#define SIGXCPU		24
#define SIGXFSZ		25
#define SIGVTALRM	26
#define SIGPROF		27
#define SIGWINCH	28
**#define SIGIO		29
#define SIGPOLL		SIGIO**