### PR TITLE
improved portability

### DIFF
--- a/client/terminal.c
+++ b/client/terminal.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(_WIN32) && !defined(_WIN64)
+#include <string.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -16,10 +17,6 @@
 #include "network.h"
 #include "utils/log.h"
 #include "utils/utils.h"
-
-#if defined (__MACOS__) || defined (__APPLE__)
-#include <string.h>
-#endif
 
 #if defined(_WIN32) || defined(_WIN64)
 #define poll WSAPoll

--- a/client/utils/linenoise.c
+++ b/client/utils/linenoise.c
@@ -208,7 +208,7 @@ static int isUnsupportedTerm(void) {
     char *term = getenv("TERM");
     int j;
 
-#if defined (__MACOS__) || defined (__APPLE__)
+#if !defined(_WIN32) && !defined(_WIN64)
 	if (term == NULL) return 1;
 #else
 	if (term == NULL) return 0;


### PR DESCRIPTION
<string.h> is needed in every unix like system, it's just that in linux is included also in <sys/un.h>
linenoise even on linux has the escape character issue in some terminals