### PR TITLE
Bugfix possible deadlock while terminating xdag

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -1,4 +1,4 @@
-/* block processing, T13.654-T14.335 $DVS:time$ */
+/* block processing, T13.654-T14.347 $DVS:time$ */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -939,9 +939,6 @@ int xdag_create_block(struct xdag_field *fields, int inputsCount, int outputsCou
 
 		while (get_timestamp() <= send_time) {
 			sleep(1);
-			if(g_stop_general_mining) {
-				return -1;
-			}
 			pthread_mutex_lock(&g_create_block_mutex);
 			struct block_internal *pretop_new = pretop_block();
 			pthread_mutex_unlock(&g_create_block_mutex);
@@ -1916,11 +1913,8 @@ void xdag_list_orphan_blocks(int count, FILE *out)
 }
 
 // completes work with the blocks
-void xdag_block_finish(int step)
+void xdag_block_finish()
 {
-	if(step == 1) {
-		pthread_mutex_lock(&g_create_block_mutex);
-	} else if(step == 2) {
-		pthread_mutex_lock(&block_mutex);
-	}
+	pthread_mutex_lock(&g_create_block_mutex);
+	pthread_mutex_lock(&block_mutex);
 }

--- a/client/block.h
+++ b/client/block.h
@@ -1,4 +1,4 @@
-/* block processing, T13.654-T14.335 $DVS:time$ */
+/* block processing, T13.654-T14.347 $DVS:time$ */
 
 #ifndef XDAG_BLOCK_H
 #define XDAG_BLOCK_H
@@ -133,7 +133,7 @@ extern int xdag_get_transactions(xdag_hash_t hash, void *data, int (*callback)(v
 void xdag_list_orphan_blocks(int, FILE*);
 
 // completes work with the blocks
-void xdag_block_finish(int);
+void xdag_block_finish(void);
 	
 #ifdef __cplusplus
 };

--- a/client/commands.c
+++ b/client/commands.c
@@ -1,4 +1,4 @@
-/* commands processing, T13.920-T14.335 $DVS:time$ */
+/* commands processing, T13.920-T14.347 $DVS:time$ */
 
 #include "commands.h"
 #include <string.h>
@@ -38,9 +38,9 @@ struct out_balances_data {
 
 typedef int (*xdag_com_func_t)(char*, FILE *);
 typedef struct {
-	char *name;				/* command name */
-	int avaibility;         /* 0 - both miner and pool, 1 - only miner, 2 - only pool */
-	xdag_com_func_t func;	/* command function */
+	char *name;			/* command name */
+	int avaibility;			/* 0 - both miner and pool, 1 - only miner, 2 - only pool */
+	xdag_com_func_t func;		/* command function */
 } XDAG_COMMAND;
 
 // Function declarations
@@ -553,12 +553,10 @@ void processInternalStatsCommand(FILE *out)
 
 void processExitCommand()
 {
-	xdag_pool_finish();
-	xdag_block_finish(1);
 	xdag_wallet_finish();
 	xdag_netdb_finish();
+	xdag_block_finish();
 	xdag_storage_finish();
-	xdag_block_finish(2);
 	xdag_mem_finish();
 }
 

--- a/client/pool.c
+++ b/client/pool.c
@@ -1,4 +1,4 @@
-/* pool logic, T14.191-T14.335 $DVS:time$ */
+/* pool logic, T14.191-T14.347 $DVS:time$ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -132,7 +132,7 @@ static uint32_t g_connections_count = 0;
 static double g_pool_fee = 0, g_pool_reward = 0, g_pool_direct = 0, g_pool_fund = 0;
 static struct xdag_block *g_firstb = 0, *g_lastb = 0;
 
-int g_stop_general_mining = 1;
+static int g_stop_general_mining = 1;
 
 static struct miner_pool_data g_pool_miner;
 static struct miner_pool_data g_fund_miner;
@@ -144,7 +144,6 @@ static miner_list_element *g_miner_list_head = NULL;
 static uint32_t g_connection_changed = 0;
 static pthread_mutex_t g_connections_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t g_pool_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t g_global_mining_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int pay_miners(xdag_time_t time);
 void remove_inactive_miners(void);
@@ -240,8 +239,6 @@ int xdag_initialize_pool(const char *pool_arg)
 
 void *general_mining_thread(void *arg)
 {
-
-	pthread_mutex_lock(&g_global_mining_mutex);
 	while(!g_xdag_sync_on && !g_stop_general_mining) {
 		sleep(1);
 	}
@@ -249,7 +246,6 @@ void *general_mining_thread(void *arg)
 	while(!g_stop_general_mining) {
 		xdag_create_block(0, 0, 0, 0, xdag_main_time() << 16 | 0xffff, NULL);
 	}
-        pthread_mutex_unlock(&g_global_mining_mutex);
 
 	xdag_mess("Stopping general mining thread...");
 
@@ -1718,11 +1714,4 @@ int xdag_print_miner_stats(const char* address, FILE *out)
 	pthread_mutex_unlock(&g_connections_mutex);
 
 	return exists;
-}
-
-void xdag_pool_finish()
-{
-	g_stop_general_mining = 1;
-	pthread_mutex_lock(&g_global_mining_mutex);
-
 }

--- a/client/pool.h
+++ b/client/pool.h
@@ -1,4 +1,4 @@
-/* pool logic, T14.191-T14.335 $DVS:time$ */
+/* pool logic, T14.191-T14.347 $DVS:time$ */
 
 #ifndef XDAG_POOL_H
 #define XDAG_POOL_H
@@ -17,7 +17,6 @@ enum disconnect_type
 
 extern xdag_hash_t g_xdag_mined_hashes[CONFIRMATIONS_COUNT];
 extern xdag_hash_t g_xdag_mined_nonce[CONFIRMATIONS_COUNT];
-extern int g_stop_general_mining;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The mutex in pool.c that i previously added is useless.
And block mutex depends on storage mutex, so i inverted finish block with finish storage order to lock block mutex first.