### PR TITLE
Hotfix, change maximum temp file size

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -1199,7 +1199,7 @@ int xdag_blocks_start(int is_pool, int mining_threads_count, int miner_address)
 		g_light_mode = 1;
 	}
 
-	if (xdag_mem_init(g_light_mode && !miner_address ? 0 : (((get_timestamp() - XDAG_ERA) >> 10) + (uint64_t)365 * 24 * 60 * 60) * 2 * sizeof(struct block_internal))) {
+	if (xdag_mem_init(g_light_mode && !miner_address ? 0 : (((get_timestamp() - XDAG_ERA) >> 8) + (uint64_t)365 * 24 * 60 * 60) * 2 * sizeof(struct block_internal))) {
 		return -1;
 	}
 


### PR DESCRIPTION
Temp file max size 34GB is almost full, with this change max size will be 74GB.
I'm doing a system to create a new file when the start file is full instead of let xdag crash.