### PR TITLE
Solving problem with extra blocks generated by pools

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -1857,7 +1857,10 @@ void remove_orphan(struct block_internal* bi, int remove_action)
 	if(!(bi->flags & BI_REF) && (remove_action != ORPHAN_REMOVE_EXTRA || (bi->flags & BI_EXTRA))) {
 		struct orphan_block *obt = bi->oref;
 		if (obt == NULL) {
-			xdag_crit("Critical error. List in the hashtable not found. The orphan is not found in hashtable. [function: remove_orphan]");
+			xdag_crit("Critical error. obt=0");
+		} else if (obt->orphan_bi != bi) {
+			xdag_crit("Critical error. bi=%p, flags=%x, action=%d, obt=%p, prev=%p, next=%p, obi=%p",
+				  bi, bi->flags, remove_action, obt, obt->prev, obt->next, obt->orphan_bi);
 		} else {
 			int index = get_orphan_index(bi), i;
 			struct orphan_block *prev = obt->prev, *next = obt->next;

--- a/client/block.h
+++ b/client/block.h
@@ -1,4 +1,4 @@
-/* block processing, T13.654-T14.347 $DVS:time$ */
+/* block processing, T13.654-T14.390 $DVS:time$ */
 
 #ifndef XDAG_BLOCK_H
 #define XDAG_BLOCK_H
@@ -99,8 +99,8 @@ extern int xdag_set_balance(xdag_hash_t hash, xdag_amount_t balance);
 // calculates current supply by specified count of main blocks
 extern xdag_amount_t xdag_get_supply(uint64_t nmain);
 
-// returns position and time of block by hash
-extern int64_t xdag_get_block_pos(const xdag_hash_t hash, xdag_time_t *time);
+// returns position and time of block by hash; if block is extra and block != 0 also returns the whole block
+extern int64_t xdag_get_block_pos(const xdag_hash_t hash, xdag_time_t *time, struct xdag_block *block);
 
 // returns a number of the current period, period is 64 seconds
 extern xdag_time_t xdag_main_time(void);

--- a/client/commands.c
+++ b/client/commands.c
@@ -515,6 +515,7 @@ void processStatsCommand(FILE *out)
 			"            hosts: %u of %u\n"
 			"           blocks: %llu of %llu\n"
 			"      main blocks: %llu of %llu\n"
+			"     extra blocks: %llu\n"
 			"    orphan blocks: %llu\n"
 			" wait sync blocks: %u\n"
 			" chain difficulty: %llx%016llx of %llx%016llx\n"
@@ -523,6 +524,7 @@ void processStatsCommand(FILE *out)
 			g_xdag_stats.nhosts, g_xdag_stats.total_nhosts,
 			(long long)g_xdag_stats.nblocks, (long long)g_xdag_stats.total_nblocks,
 			(long long)g_xdag_stats.nmain, (long long)g_xdag_stats.total_nmain,
+			(long long)g_xdag_extstats.nextra,
 			(long long)g_xdag_extstats.nnoref, g_xdag_extstats.nwaitsync,
 			xdag_diff_args(g_xdag_stats.difficulty),
 			xdag_diff_args(g_xdag_stats.max_difficulty), g_coinname,

--- a/client/init.h
+++ b/client/init.h
@@ -33,6 +33,7 @@ extern struct xdag_ext_stats
 	xdag_diff_t hashrate_ours[HASHRATE_LAST_MAX_TIME];
 	xdag_time_t hashrate_last_time;
 	uint64_t nnoref;
+	uint64_t nextra;
 	uint64_t nhashes;
 	double hashrate_s;
 	uint32_t nwaitsync;

--- a/client/miner.c
+++ b/client/miner.c
@@ -1,4 +1,4 @@
-/* пул и майнер, T13.744-T13.895 $DVS:time$ */
+/* пул и майнер, T13.744-T14.390 $DVS:time$ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -172,18 +172,20 @@ begin:
 		goto err;
 	}
 
-	const int64_t pos = xdag_get_block_pos(hash, &t);
-	if(pos < 0) {
+	const int64_t pos = xdag_get_block_pos(hash, &t, &b);
+	if (pos == -2l) {
+		;
+	} else if (pos < 0) {
 		mess = "can't find the block";
 		goto err;
+	} else {
+		struct xdag_block *blk = xdag_storage_load(hash, t, pos, &b);
+		if(!blk) {
+			mess = "can't load the block";
+			goto err;
+		}
+		if(blk != &b) memcpy(&b, blk, sizeof(struct xdag_block));
 	}
-
-	struct xdag_block *blk = xdag_storage_load(hash, t, pos, &b);
-	if(!blk) {
-		mess = "can't load the block";
-		goto err;
-	}
-	if(blk != &b) memcpy(&b, blk, sizeof(struct xdag_block));
 
 	pthread_mutex_lock(&g_miner_mutex);
 	g_socket = xdag_connect_pool(pool_address, &mess);

--- a/client/transport.c
+++ b/client/transport.c
@@ -1,4 +1,4 @@
-/* транспорт, T13.654-T14.328 $DVS:time$ */
+/* транспорт, T13.654-T14.390 $DVS:time$ */
 
 #include <stdlib.h>
 #include <string.h>
@@ -153,9 +153,11 @@ static int process_transport_block(struct xdag_block *received_block, void *conn
 		{
 			struct xdag_block buf, *blk;
 			xdag_time_t t;
-			int64_t pos = xdag_get_block_pos(received_block->field[1].hash, &t);
+			int64_t pos = xdag_get_block_pos(received_block->field[1].hash, &t, &buf);
 
-			if(pos >= 0 && (blk = xdag_storage_load(received_block->field[1].hash, t, pos, &buf))) {
+			if (pos == -2l) {
+				dnet_send_xdag_packet(&buf, connection);
+			} else if (pos >= 0 && (blk = xdag_storage_load(received_block->field[1].hash, t, pos, &buf))) {
 				dnet_send_xdag_packet(blk, connection);
 			}
 


### PR DESCRIPTION
Каждый пул каждые 64 секунды генерирует блок для соревнования за лучший хеш. Все эти блоки, кроме одного, не нужны и занимают лишнее место. Данный патч позволяет избавиться от большинства из них, даже если некоторые пулы не поддерживают этих правил.

Все такие блоки, участвующие в соревновании, по умолчанию считаются лишними и помечаются новым флагом BI_EXTRA. Лишние блоки не сохраняются на диск и не рассылаются другим пулам за исключением блоков с рекордной сложностью. Кроме того, на лишние блоки мы не ссылаемся, за исключением случая, когда ссылка нужна для встраивания в цепочку главных блоков. Если какой-то блок ссылается на лишний, то последний перестаёт быть лишним. Иначе лишние блоки накапливаются до определённого числа, а потом используются заново.

Также данный патч улучшает работу с блоками, на которые никто не ссылается (orphan). Раньше они были организованы в виде хеш-таблицы, но хеш-таблица не нужна, так как удаление из двунаправленного списка можно организовать за O(1) операций. Поэтому вместо хеш-таблицы сделаны два списка: в нулевом хранятся нелишние блоки, на которые нет ссылок, а в первом лишние.