### PR TITLE
Fix oref dereference instead of ref

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -1607,7 +1607,7 @@ int xdag_print_block_info(xdag_hash_t hash, FILE *out)
 	fprintf(out, "                               block as transaction: details\n");
 	fprintf(out, " direction  address                                    amount\n");
 	fprintf(out, "-------------------------------------------------------------------------------------------\n");
-	if(bi->ref) {
+	if((bi->flags & BI_REF) && bi->ref != NULL) {
 		xdag_hash2address(bi->ref->hash, address);
 	} else {
 		strcpy(address, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");


### PR DESCRIPTION
Bugfix: bi->ref is not null because it refer to the orphan_block, need to check it is BI_REF too