### PR TITLE
split dnet log from xdag log.

### DIFF
--- a/client/utils/log.c
+++ b/client/utils/log.c
@@ -19,7 +19,6 @@
 
 //#define LOG_PRINT // print log to stdout
 
-#define XDAG_LOG_FILE "%s.log"
 #define RING_BUFFER_SIZE 2048
 #define MAX_POLL_SIZE (RING_BUFFER_SIZE - 4)
 #define SEM_LOG_WRITER "/xdaglogwritersem"
@@ -155,7 +154,7 @@ static void *xdag_log_writer_thread(void* data)
 }
 #endif
 
-int xdag_log(int level, const char *format, ...)
+int xdag_log(const char *logfile, int level, const char *format, ...)
 {	
 #if ASYNC_LOG && (!defined _WIN32 && !defined _WIN64)
 	if (level < 0 || level > XDAG_TRACE) {
@@ -221,7 +220,7 @@ int xdag_log(int level, const char *format, ...)
 	strftime(tbuf, 64, "%Y-%m-%d %H:%M:%S", &tm);
 	
 	pthread_mutex_lock(&log_mutex);
-	sprintf(buf, XDAG_LOG_FILE, g_progname);
+	sprintf(buf, "%s", logfile);
 	
 	f = xdag_open_file(buf, "a");
 	if (!f) {

--- a/client/utils/log.h
+++ b/client/utils/log.h
@@ -20,7 +20,7 @@ enum xdag_debug_levels {
 extern "C" {
 #endif
 	
-extern int xdag_log(int level, const char *format, ...);
+extern int xdag_log(const char *logfile, int level, const char *format, ...);
 
 extern char *xdag_log_array(const void *arr, unsigned size);
 
@@ -35,16 +35,31 @@ extern int xdag_set_log_level(int level);
 };
 #endif
 
-#define xdag_fatal(...) xdag_log(XDAG_FATAL   , __VA_ARGS__)
-#define xdag_crit(...)  xdag_log(XDAG_CRITICAL, __VA_ARGS__)
-#define xdag_err(...)   xdag_log(XDAG_ERROR   , __VA_ARGS__)
-#define xdag_warn(...)  xdag_log(XDAG_WARNING , __VA_ARGS__)
-#define xdag_mess(...)  xdag_log(XDAG_MESSAGE , __VA_ARGS__)
-#define xdag_info(...)  xdag_log(XDAG_INFO    , __VA_ARGS__)
+#define XDAG_LOG_FILE "xdag.log"
+#define DNET_LOG_FILE "dnet.log"
+
+#define xdag_fatal(...) xdag_log(XDAG_LOG_FILE, XDAG_FATAL   , __VA_ARGS__)
+#define xdag_crit(...)  xdag_log(XDAG_LOG_FILE, XDAG_CRITICAL, __VA_ARGS__)
+#define xdag_err(...)   xdag_log(XDAG_LOG_FILE, XDAG_ERROR   , __VA_ARGS__)
+#define xdag_warn(...)  xdag_log(XDAG_LOG_FILE, XDAG_WARNING , __VA_ARGS__)
+#define xdag_mess(...)  xdag_log(XDAG_LOG_FILE, XDAG_MESSAGE , __VA_ARGS__)
+#define xdag_info(...)  xdag_log(XDAG_LOG_FILE, XDAG_INFO    , __VA_ARGS__)
 #ifndef NDEBUG
-#define xdag_debug(...) xdag_log(XDAG_DEBUG   , __VA_ARGS__)
+#define xdag_debug(...) xdag_log(XDAG_LOG_FILE, XDAG_DEBUG   , __VA_ARGS__)
 #else
 #define xdag_debug(...)
+#endif
+
+#define dnet_fatal(...) xdag_log(DNET_LOG_FILE, XDAG_FATAL   , __VA_ARGS__)
+#define dnet_crit(...)  xdag_log(DNET_LOG_FILE, XDAG_CRITICAL, __VA_ARGS__)
+#define dnet_err(...)   xdag_log(DNET_LOG_FILE, XDAG_ERROR   , __VA_ARGS__)
+#define dnet_warn(...)  xdag_log(DNET_LOG_FILE, XDAG_WARNING , __VA_ARGS__)
+#define dnet_mess(...)  xdag_log(DNET_LOG_FILE, XDAG_MESSAGE , __VA_ARGS__)
+#define dnet_info(...)  xdag_log(DNET_LOG_FILE, XDAG_INFO    , __VA_ARGS__)
+#ifndef NDEBUG
+#define dnet_debug(...) xdag_log(DNET_LOG_FILE, XDAG_DEBUG   , __VA_ARGS__)
+#else
+#define dnet_debug(...)
 #endif
 
 #endif

--- a/dnet/dnet_xdag.c
+++ b/dnet/dnet_xdag.c
@@ -174,7 +174,7 @@ static struct xconnection *add_connection(int fd, uint32_t ip, uint16_t port, in
 {
 	int rnd = rand() % g_nthreads;
 	if(dnet_connection_open_check && (*dnet_connection_open_check)(ip, port)) {
-		xdag_info("DNET  : failed %s %d.%d.%d.%d:%d, rejected by white list",
+		dnet_info("DNET  : failed %s %d.%d.%d.%d:%d, rejected by white list",
 			(direction ? "from" : "to  "),
 			ip & 0xff, ip >> 8 & 0xff, ip >> 16 & 0xff, ip >> 24 & 0xff, port);
 		return 0;
@@ -195,7 +195,7 @@ static struct xconnection *add_connection(int fd, uint32_t ip, uint16_t port, in
 			t->fds[nfd].fd = fd;
 			t->nconnections++;
 			pthread_mutex_unlock(&t->mutex);
-			xdag_info("DNET  : opened %s %d.%d.%d.%d:%d, nthread=%d, nfd=%d, fd=%d, conn=%p",
+			dnet_info("DNET  : opened %s %d.%d.%d.%d:%d, nthread=%d, nfd=%d, fd=%d, conn=%p",
 				(direction ? "from" : "to  "),
 				ip & 0xff, ip >> 8 & 0xff, ip >> 16 & 0xff, ip >> 24 & 0xff, port,
 				nthread, nfd, fd, conn);
@@ -203,7 +203,7 @@ static struct xconnection *add_connection(int fd, uint32_t ip, uint16_t port, in
 		}
 		pthread_mutex_unlock(&t->mutex);
 	}
-	xdag_err("DNET  : failed %s %d.%d.%d.%d:%d, no space in conn table",
+	dnet_err("DNET  : failed %s %d.%d.%d.%d:%d, no space in conn table",
 		(direction ? "from" : "to  "),
 		ip & 0xff, ip >> 8 & 0xff, ip >> 16 & 0xff, ip >> 24 & 0xff, port);
 	return 0;
@@ -256,7 +256,7 @@ static int close_connection(struct xconnection *conn, int error)
 	conn->out_queue_size = 0;
 	pthread_mutex_unlock(&conn->mutex);
 	while(xs) { xs1 = xs->next; free(xs); xs = xs1; }
-	xdag_info("DNET  : closed with %d.%d.%d.%d:%d, nthread=%d, nfd=%d, fd=%d, conn=%p, "
+	dnet_info("DNET  : closed with %d.%d.%d.%d:%d, nthread=%d, nfd=%d, fd=%d, conn=%p, "
 		"in/out/drop=%ld/%ld/%ld, time=%ld, last_time=%d, err=%x",
 		conn->ip & 0xff, conn->ip >> 8 & 0xff, conn->ip >> 16 & 0xff, conn->ip >> 24 & 0xff, conn->port,
 		nthread, nfd, fd, conn, conn->packets_in, conn->packets_out, conn->dropped_in,
@@ -581,12 +581,12 @@ static int dnet_load_keys(void)
 {
 	FILE *f = xdag_open_file("dnet_keys.bin", "rb");
 	if(!f) {
-		xdag_err("Load dnet keys failed");
+		dnet_err("Load dnet keys failed");
 		return -1;
 	}
 
 	if(fread(&g_xkeys, sizeof(struct xdnet_keys), 1, f) != 1) {
-		xdag_err("Load dnet keys failed");
+		dnet_err("Load dnet keys failed");
 		xdag_close_file(f);
 		return -1;
 	}
@@ -693,14 +693,14 @@ int dnet_execute_command(const char *cmd, void *fileout)
 		fd = open_socket(&peeraddr, str);
 		if(fd < 0) {
 			fprintf(f, "connect: error opening the socket\n");
-			xdag_err("DNET  : failed to   %s, can't open socket", str);
+			dnet_err("DNET  : failed to   %s, can't open socket", str);
 			return -1;
 		}
 		if(connect(fd, (struct sockaddr *)&peeraddr, sizeof(peeraddr))) {
 			close(fd);
 			fprintf(f, "connect: error connecting the socket (ip=%08x, port=%d)\n",
 				htonl(peeraddr.sin_addr.s_addr), htons(peeraddr.sin_port));
-			xdag_info("DNET  : failed to   %s, can't connect", str);
+			dnet_info("DNET  : failed to   %s, can't connect", str);
 			return -1;
 		}
 		if(!add_connection(fd, peeraddr.sin_addr.s_addr, htons(peeraddr.sin_port), 0)) {


### PR DESCRIPTION
* split dnet log from xdag log.

The previous implementation merged dnet and xdag, it's not so convenient to detect dnet issues.