### PR TITLE
Detach block tree

### DIFF
--- a/client/commands.c
+++ b/client/commands.c
@@ -1,4 +1,4 @@
-/* commands processing, T13.920-T14.423 $DVS:time$ */
+/* commands processing, T13.920-T14.511 $DVS:time$ */
 
 #include "commands.h"
 #include <string.h>
@@ -45,7 +45,7 @@ typedef struct {
 	xdag_com_func_t func;		/* command function */
 } XDAG_COMMAND;
 
-extern int g_use_tmpfile;
+extern int g_use_tmpfile, g_detach_tree;
 
 // Function declarations
 int account_callback(void *data, xdag_hash_t hash, xdag_amount_t amount, xdag_time_t time, int n_our_key);
@@ -560,14 +560,18 @@ void processInternalStatsCommand(FILE *out)
 		"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
 		"Temp file   :\n"
 		"       state: %s\n"
-                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+		"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+		"Detach tree :\n"
+		"       state: %s\n"
+		"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
 		"Optimized ec:\n"
 		"       state: %s\n"
-                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+		"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
 		"Cache informations:\n"
 		"     cached blocks: target amount %u, actual amount %u, hitrate %f%%\n"
-                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-		(g_use_tmpfile ? "Active" : "Inactive" ), (USE_OPTIMIZED_EC ? "Active" : "Inactive" ), 
+		"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+		(g_use_tmpfile ? "Active" : "Inactive" ), (g_detach_tree ? "Active" : "Inactive" ), 
+		(USE_OPTIMIZED_EC ? "Active" : "Inactive" ), 
 		g_xdag_extstats.cache_size, g_xdag_extstats.cache_usage, g_xdag_extstats.cache_hitrate*100
 	);
 }

--- a/client/init.c
+++ b/client/init.c
@@ -1,4 +1,4 @@
-/* cheatcoin main, T13.654-T14.325 $DVS:time$ */
+/* cheatcoin main, T13.654-T14.511 $DVS:time$ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +37,7 @@ char *g_coinname, *g_progname;
 int g_xdag_state = XDAG_STATE_INIT;
 int g_xdag_testnet = 0;
 int g_is_miner = 0;
+extern int g_detach_tree;
 static int g_is_pool = 0;
 int g_xdag_run = 0;
 time_t g_xdag_xfer_last = 0;
@@ -170,6 +171,8 @@ int xdag_init(int argc, char **argv, int isGui)
 				printUsage(argv[0]);
 				return -1;
 			}
+		} else if(ARG_EQUAL(argv[i], "-D", "")) { /* disable detach tree */
+			g_detach_tree = 0;
 		} else {
 			printUsage(argv[0]);
 			return 0;
@@ -304,5 +307,7 @@ void printUsage(char* appName)
 		"  -threads N     - create N transport layer threads for pool (default is 6)\n"
 		"  -dm            - disable mining on pool (-P option is ignored)\n"
 		"  -tag           - tag for pool to distingush pools. Max length is 31 chars\n"
+		"  -D             - disable block tree detach. Detach tree improve performance while using\n"
+		"                    temp file, note that: tree detach is always disabled while using -z RAM\n"
 		, appName);
 }

--- a/client/netdb.c
+++ b/client/netdb.c
@@ -1,4 +1,4 @@
-/* база хостов, T13.714-T13.841 $DVS:time$ */
+/* база хостов, T13.714-T14.511 $DVS:time$ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,7 +53,7 @@ static inline int lessthan(struct ldus_rbtree *l, struct ldus_rbtree *r)
 	return lh->ip < rh->ip || (lh->ip == rh->ip && lh->port < rh->port);
 }
 
-ldus_rbtree_define_prefix(lessthan, static inline, )
+ldus_rbtree_define_prefix(lessthan, static inline, , )
 
 static struct ldus_rbtree *root = 0;
 static pthread_mutex_t host_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/ldus/source/include/ldus/rbtree.h
+++ b/ldus/source/include/ldus/rbtree.h
@@ -1,4 +1,4 @@
-/* red-black tree, T11.684-T13.285; $DVS:time$ */
+/* red-black tree, T11.684-T14.511; $DVS:time$ */
 
 #ifndef	LDUS_RBTREE_H_INCLUDED
 #define LDUS_RBTREE_H_INCLUDED
@@ -184,29 +184,29 @@ static inline int _rbtree_remove_right(struct ldus_rbtree **proot, struct ldus_r
 	}
 }
 
-#define ldus_rbtree_define_prefix(lessthan, prefix, postfix) \
+#define ldus_rbtree_define_prefix(lessthan, prefix, infix, postfix) \
    \
-prefix int ldus_rbtree_insert(struct ldus_rbtree **proot, struct ldus_rbtree *node) { \
+prefix int ldus_rbtree_insert ## infix(struct ldus_rbtree **proot, struct ldus_rbtree *node) { \
 	struct ldus_rbtree *root = _rbtree_ptr(*proot); \
 	if (!root) { *proot = node, node->left = node->right = 0; return 1; } \
-	if (lessthan(node, root)) return _rbtree_insert_balance_left (proot, ldus_rbtree_insert(&root->left,  node)); \
-	if (lessthan(root, node)) return _rbtree_insert_balance_right(proot, ldus_rbtree_insert(&root->right, node)); \
+	if (lessthan(node, root)) return _rbtree_insert_balance_left (proot, ldus_rbtree_insert ## infix(&root->left,  node)); \
+	if (lessthan(root, node)) return _rbtree_insert_balance_right(proot, ldus_rbtree_insert ## infix(&root->right, node)); \
 	return -1; \
 } \
     \
-prefix struct ldus_rbtree *ldus_rbtree_find(struct ldus_rbtree *root, struct ldus_rbtree *node) postfix { \
+prefix struct ldus_rbtree *ldus_rbtree_find ## infix(struct ldus_rbtree *root, struct ldus_rbtree *node) postfix { \
 	root = _rbtree_ptr(root); \
 	if (!root) return 0; \
-	if (lessthan(node, root)) return ldus_rbtree_find(root->left,  node); \
-	if (lessthan(root, node)) return ldus_rbtree_find(root->right, node); \
+	if (lessthan(node, root)) return ldus_rbtree_find ## infix(root->left,  node); \
+	if (lessthan(root, node)) return ldus_rbtree_find ## infix(root->right, node); \
 	return root; \
 } \
     \
-prefix int ldus_rbtree_remove(struct ldus_rbtree **proot, struct ldus_rbtree *node) { \
+prefix int ldus_rbtree_remove ## infix(struct ldus_rbtree **proot, struct ldus_rbtree *node) { \
 	struct ldus_rbtree *root = _rbtree_ptr(*proot); \
 	if (!root) return -1; \
-	if (lessthan(node, root)) return _rbtree_remove_balance_left (proot,  ldus_rbtree_remove (&root->left,  node )); \
-	if (lessthan(root, node)) return _rbtree_remove_balance_right(proot,  ldus_rbtree_remove (&root->right, node )); \
+	if (lessthan(node, root)) return _rbtree_remove_balance_left (proot,  ldus_rbtree_remove ## infix(&root->left,  node )); \
+	if (lessthan(root, node)) return _rbtree_remove_balance_right(proot,  ldus_rbtree_remove ## infix(&root->right, node )); \
 	if (root->left )          return _rbtree_remove_balance_left (proot, _rbtree_remove_left (&root->left,  proot)); \
 	if (root->right)          return _rbtree_remove_balance_right(proot, _rbtree_remove_right(&root->right, proot)); \
 	if (_rbtree_color(*proot)) { *proot = 0; return 0; } \


### PR DESCRIPTION
In this way nodes of the tree are smaller and it is possible to keep the tree in ram (for 80 millions it should use around 4GB of ram [(64b+64b+64b+192b)*80millions= 3.8GB])
The informations of blocks will be in tmp file, total ram usage should be around 10GB.

Actually the issue with tmpfile is that to search, insert and balance the tree you have to unfold the nodes of the tree, that are in the tmp file. It is too much slow. In search, insert, balance you unfold random tree nodes that are in random portion of tmp file, operative system cannot do any caching this way.
With this change it is almost fast as -z RAM but using tmp file.