### PR TITLE
add index of internal blocks

### DIFF
--- a/client/transport.c
+++ b/client/transport.c
@@ -341,7 +341,10 @@ static int do_request(int type, xdag_time_t start_time, xdag_time_t end_time, vo
 	
 	if (type == XDAG_MESSAGE_SUMS_REQUEST) {
 		reply_connection = dnet_send_xdag_packet(&b, 0);
-		if (!reply_connection) return 0;
+		if (!reply_connection) {
+			pthread_mutex_unlock(&g_process_mutex);
+			return 0;
+		}
 	} else {
 		dnet_send_xdag_packet(&b, reply_connection);
 	}


### PR DESCRIPTION
* add index of internal blocks

It's based on #409 

Create index for all internal blocks in RAM with hash and address of internal blocks to avoid too many page faults when doing rbtree searches, since internal blocks are stored in mmap memory which is actually on disk . It will take about 5G extra RAM when use tmp files, but speed up the loading and syncing process, performance is similar with -z RAM option.

With 8G RAM and SSD, it will take about 7 hours to load storage, syncing is still in testing right now.