### PR TITLE
Sha-256 algorithm is improved

### DIFF
--- a/client/sha256.c
+++ b/client/sha256.c
@@ -1,87 +1,125 @@
-/*********************************************************************
-* Filename:   sha256.c
-* Author:     Brad Conte (brad AT bradconte.com)
-* Copyright:
-* Disclaimer: This code is presented "as is" without any guarantees.
-* Details:    Implementation of the SHA-256 hashing algorithm.
-              SHA-256 is one of the three algorithms in the SHA2
-              specification. The others, SHA-384 and SHA-512, are not
-              offered in this implementation.
-              Algorithm specification can be found here:
-               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
-              This implementation uses little endian byte order.
-*********************************************************************/
-
-/*************************** HEADER FILES ***************************/
 #include <stdlib.h>
 #include <memory.h>
 #include <openssl/sha.h>
 #include "sha256.h"
 
-/****************************** MACROS ******************************/
-#define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
-#define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))
-
-#define CH(x,y,z) (((x) & (y)) ^ (~(x) & (z)))
-#define MAJ(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
-#define EP0(x) (ROTRIGHT(x,2) ^ ROTRIGHT(x,13) ^ ROTRIGHT(x,22))
-#define EP1(x) (ROTRIGHT(x,6) ^ ROTRIGHT(x,11) ^ ROTRIGHT(x,25))
-#define SIG0(x) (ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3))
-#define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
-
-/**************************** VARIABLES *****************************/
-#ifndef SHA256_USE_OPENSSL_TXFM
-static const xWORD k[64] = {
-	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
-	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
-	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
-	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
-	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
-	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
-	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
-	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
-};
-
-/*********************** FUNCTION DEFINITIONS ***********************/
-static void sha256_transform(SHA256REF_CTX *ctx, const xBYTE data[])
+inline uint32_t bswap_32(uint32_t x)
 {
-	xWORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+	return (((x & 0xff000000U) >> 24) | ((x & 0x00ff0000U) >> 8) |
+		((x & 0x0000ff00U) << 8) | ((x & 0x000000ffU) << 24));
+}
 
-	for (i = 0, j = 0; i < 16; ++i, j += 4)
-		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
-	for ( ; i < 64; ++i)
-		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+uint32_t static inline ReadBE32(const unsigned char* ptr)
+{
+	return bswap_32(*(uint32_t*)ptr);
+}
 
-	a = ctx->state[0];
-	b = ctx->state[1];
-	c = ctx->state[2];
-	d = ctx->state[3];
-	e = ctx->state[4];
-	f = ctx->state[5];
-	g = ctx->state[6];
-	h = ctx->state[7];
+void static inline WriteBE32(uint32_t* ptr, uint32_t x)
+{
+	*ptr = bswap_32(x);
+}
 
-	for (i = 0; i < 64; ++i) {
-		t1 = h + EP1(e) + CH(e,f,g) + k[i] + m[i];
-		t2 = EP0(a) + MAJ(a,b,c);
-		h = g;
-		g = f;
-		f = e;
-		e = d + t1;
-		d = c;
-		c = b;
-		b = a;
-		a = t1 + t2;
-	}
+#ifndef SHA256_USE_OPENSSL_TXFM
 
-	ctx->state[0] += a;
-	ctx->state[1] += b;
-	ctx->state[2] += c;
-	ctx->state[3] += d;
-	ctx->state[4] += e;
-	ctx->state[5] += f;
-	ctx->state[6] += g;
-	ctx->state[7] += h;
+uint32_t inline Ch(uint32_t x, uint32_t y, uint32_t z) { return z ^ (x & (y ^ z)); }
+uint32_t inline Maj(uint32_t x, uint32_t y, uint32_t z) { return (x & y) | (z & (x | y)); }
+uint32_t inline Sigma0(uint32_t x) { return (x >> 2 | x << 30) ^ (x >> 13 | x << 19) ^ (x >> 22 | x << 10); }
+uint32_t inline Sigma1(uint32_t x) { return (x >> 6 | x << 26) ^ (x >> 11 | x << 21) ^ (x >> 25 | x << 7); }
+uint32_t inline sigma0(uint32_t x) { return (x >> 7 | x << 25) ^ (x >> 18 | x << 14) ^ (x >> 3); }
+uint32_t inline sigma1(uint32_t x) { return (x >> 17 | x << 15) ^ (x >> 19 | x << 13) ^ (x >> 10); }
+
+/** One round of SHA-256. */
+void inline Round(uint32_t a, uint32_t b, uint32_t c, uint32_t *d, uint32_t e, uint32_t f, uint32_t g, uint32_t *h, uint32_t k, uint32_t w)
+{
+	uint32_t t1 = *h + Sigma1(e) + Ch(e, f, g) + k + w;
+	uint32_t t2 = Sigma0(a) + Maj(a, b, c);
+	*d += t1;
+	*h = t1 + t2;
+}
+
+static void sha256_transform(SHA256REF_CTX *ctx, const uint8_t *chunk)
+{
+	uint32_t* s = ctx->state;
+	uint32_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
+	uint32_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
+
+	Round(a, b, c, &d, e, f, g, &h, 0x428a2f98, w0 = ReadBE32(chunk + 0));
+	Round(h, a, b, &c, d, e, f, &g, 0x71374491, w1 = ReadBE32(chunk + 4));
+	Round(g, h, a, &b, c, d, e, &f, 0xb5c0fbcf, w2 = ReadBE32(chunk + 8));
+	Round(f, g, h, &a, b, c, d, &e, 0xe9b5dba5, w3 = ReadBE32(chunk + 12));
+	Round(e, f, g, &h, a, b, c, &d, 0x3956c25b, w4 = ReadBE32(chunk + 16));
+	Round(d, e, f, &g, h, a, b, &c, 0x59f111f1, w5 = ReadBE32(chunk + 20));
+	Round(c, d, e, &f, g, h, a, &b, 0x923f82a4, w6 = ReadBE32(chunk + 24));
+	Round(b, c, d, &e, f, g, h, &a, 0xab1c5ed5, w7 = ReadBE32(chunk + 28));
+	Round(a, b, c, &d, e, f, g, &h, 0xd807aa98, w8 = ReadBE32(chunk + 32));
+	Round(h, a, b, &c, d, e, f, &g, 0x12835b01, w9 = ReadBE32(chunk + 36));
+	Round(g, h, a, &b, c, d, e, &f, 0x243185be, w10 = ReadBE32(chunk + 40));
+	Round(f, g, h, &a, b, c, d, &e, 0x550c7dc3, w11 = ReadBE32(chunk + 44));
+	Round(e, f, g, &h, a, b, c, &d, 0x72be5d74, w12 = ReadBE32(chunk + 48));
+	Round(d, e, f, &g, h, a, b, &c, 0x80deb1fe, w13 = ReadBE32(chunk + 52));
+	Round(c, d, e, &f, g, h, a, &b, 0x9bdc06a7, w14 = ReadBE32(chunk + 56));
+	Round(b, c, d, &e, f, g, h, &a, 0xc19bf174, w15 = ReadBE32(chunk + 60));
+
+	Round(a, b, c, &d, e, f, g, &h, 0xe49b69c1, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0xefbe4786, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x0fc19dc6, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x240ca1cc, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x2de92c6f, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x4a7484aa, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x5cb0a9dc, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x76f988da, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0x983e5152, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0xa831c66d, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0xb00327c8, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0xbf597fc7, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0xc6e00bf3, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xd5a79147, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0x06ca6351, w14 += sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0x14292967, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+	Round(a, b, c, &d, e, f, g, &h, 0x27b70a85, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0x2e1b2138, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x4d2c6dfc, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x53380d13, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x650a7354, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x766a0abb, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x81c2c92e, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x92722c85, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0xa2bfe8a1, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0xa81a664b, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0xc24b8b70, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0xc76c51a3, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0xd192e819, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xd6990624, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0xf40e3585, w14 += sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0x106aa070, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+	Round(a, b, c, &d, e, f, g, &h, 0x19a4c116, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0x1e376c08, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x2748774c, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x34b0bcb5, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x391c0cb3, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x4ed8aa4a, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x5b9cca4f, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x682e6ff3, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0x748f82ee, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0x78a5636f, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0x84c87814, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0x8cc70208, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0x90befffa, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xa4506ceb, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0xbef9a3f7, w14 + sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0xc67178f2, w15 + sigma1(w13) + w8 + sigma0(w0));
+
+	s[0] += a;
+	s[1] += b;
+	s[2] += c;
+	s[3] += d;
+	s[4] += e;
+	s[5] += f;
+	s[6] += g;
+	s[7] += h;
+	chunk += 64;
 }
 
 #else
@@ -104,64 +142,54 @@ void sha256_init(SHA256REF_CTX *ctx)
 	ctx->md_len = SHA256_BLOCK_SIZE;
 }
 
-void sha256_update(SHA256REF_CTX *ctx, const xBYTE data[], size_t len)
+void sha256_update(SHA256REF_CTX *ctx, const uint8_t *data, size_t len)
 {
-	xWORD i;
-	xBYTE *cdata = (xBYTE *)ctx->data;
+	uint8_t *cdata = (uint8_t *)ctx->data;
 
-	for (i = 0; i < len; ++i) {
-		cdata[ctx->datalen] = data[i];
-		ctx->datalen++;
-		if (ctx->datalen == 64) {
+	while(len > 0) {
+		if(ctx->datalen + len >= 64) {
+			memcpy(cdata + ctx->datalen, data, 64 - ctx->datalen);
 			sha256_transform(ctx, cdata);
+			len -= 64 - ctx->datalen;
+			data += 64;
 			ctx->bitlen += 512;
 			ctx->datalen = 0;
+		} else {
+			memcpy(cdata + ctx->datalen, data, len);
+			ctx->datalen += (uint32_t)len;
+			len = 0;
 		}
 	}
 }
 
-void sha256_final(SHA256REF_CTX *ctx, xBYTE hash[])
+void sha256_final(SHA256REF_CTX *ctx, uint8_t *hash)
 {
-	xWORD i;
-	xBYTE *cdata = (xBYTE *)ctx->data;
-
-	i = ctx->datalen;
+	uint8_t *cdata = (uint8_t *)ctx->data;
+	uint32_t tmp_len = ctx->datalen;
 
 	// Pad whatever data is left in the buffer.
-	if (ctx->datalen < 56) {
-		cdata[i++] = 0x80;
-		while (i < 56)
-			cdata[i++] = 0x00;
+	if(ctx->datalen < 56) {
+		cdata[tmp_len++] = 0x80;
+		memset(cdata + tmp_len, 0, 56 - tmp_len);
 	} else {
-		cdata[i++] = 0x80;
-		while (i < 64)
-			cdata[i++] = 0x00;
-		sha256_transform(ctx, cdata);
+		cdata[tmp_len++] = 0x80;
+		memset(cdata + tmp_len, 0, 56 - tmp_len);
+		SHA256_Transform(ctx, cdata);
 		memset(cdata, 0, 56);
 	}
 
 	// Append to the padding the total message's length in bits and transform.
-	ctx->bitlen += ctx->datalen * 8;
-	cdata[63] = ctx->bitlen;
-	cdata[62] = ctx->bitlen >> 8;
-	cdata[61] = ctx->bitlen >> 16;
-	cdata[60] = ctx->bitlen >> 24;
-	cdata[59] = ctx->bitlenH;
-	cdata[58] = ctx->bitlenH >> 8;
-	cdata[57] = ctx->bitlenH >> 16;
-	cdata[56] = ctx->bitlenH >> 24;
-	sha256_transform(ctx, cdata);
+	ctx->bitlen += ctx->datalen << 3;
+	*((uint32_t*)(cdata + 60)) = bswap_32((uint32_t)ctx->bitlen);
+	*((uint32_t*)(cdata + 56)) = bswap_32((uint32_t)(ctx->bitlenH));	//TODO: ctx->bitlenH is always zero. Do we need it?
+	SHA256_Transform(ctx, cdata);
 
-	// Since this implementation uses little endian byte ordering and SHA uses big endian,
-	// reverse all the bytes when copying the final state to the output hash.
-	for (i = 0; i < 4; ++i) {
-		hash[i]      = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 4]  = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 8]  = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
-	}
+	WriteBE32((uint32_t*)hash, ctx->state[0]);
+	WriteBE32((uint32_t*)(hash + 4), ctx->state[1]);
+	WriteBE32((uint32_t*)(hash + 8), ctx->state[2]);
+	WriteBE32((uint32_t*)(hash + 12), ctx->state[3]);
+	WriteBE32((uint32_t*)(hash + 16), ctx->state[4]);
+	WriteBE32((uint32_t*)(hash + 20), ctx->state[5]);
+	WriteBE32((uint32_t*)(hash + 24), ctx->state[6]);
+	WriteBE32((uint32_t*)(hash + 28), ctx->state[7]);
 }

--- a/client/sha256.h
+++ b/client/sha256.h
@@ -11,33 +11,23 @@
 
 /*************************** HEADER FILES ***************************/
 #include <stddef.h>
+#include <stdint.h>
 #include <openssl/sha.h>
 
 /****************************** MACROS ******************************/
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
 
 /**************************** DATA TYPES ****************************/
-typedef unsigned char xBYTE;             // 8-bit byte
-typedef unsigned int  xWORD;             // 32-bit word, change to "long" for 16-bit machines
 
-#if 0	// original implementation
-typedef struct {
-	xWORD state[8];
-	unsigned long long bitlen;
-	xBYTE data[64];
-	xWORD datalen, md_len;
-} SHA256REF_CTX;
-#else	// openssl hack
 typedef SHA256_CTX SHA256REF_CTX;
 #define state h
 #define bitlen Nl
 #define bitlenH Nh
 #define datalen num
-#endif
 
 /*********************** FUNCTION DECLARATIONS **********************/
 void sha256_init(SHA256REF_CTX *ctx);
-void sha256_update(SHA256REF_CTX *ctx, const xBYTE data[], size_t len);
-void sha256_final(SHA256REF_CTX *ctx, xBYTE hash[]);
+void sha256_update(SHA256REF_CTX *ctx, const uint8_t *data, size_t len);
+void sha256_final(SHA256REF_CTX *ctx, uint8_t *hash);
 
 #endif   // SHA256_H


### PR DESCRIPTION
SHA-256 algorithm is rewritten: 35% faster without SSL and about 18% faster with SSL.
Affects only loading of storage and syncronization. CPU-mining uses another algorithm (see hash.c)

![default](https://user-images.githubusercontent.com/6870809/48922443-c9640000-eeb7-11e8-9c87-99c1ae17a3b7.png)
