### PR TITLE
divide xtime from frame

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -1186,7 +1186,7 @@ begin:
 				g_xdag_state == XDAG_STATE_SYNC || g_xdag_state == XDAG_STATE_STST || 
 				g_xdag_state == XDAG_STATE_CONN || g_xdag_state == XDAG_STATE_CTST)) {
 			if (g_xdag_state == XDAG_STATE_SYNC || g_xdag_state == XDAG_STATE_STST || 
-					g_xdag_stats.nmain >= (MAIN_TIME(t) - xdag_start_main_time())) {
+					g_xdag_stats.nmain >= (MAIN_TIME(t) - xdag_get_start_frame())) {
 				g_block_production_on = 1;
 			} else if (last_nmain != nmain) {
 				last_nmain = nmain;

--- a/client/block.h
+++ b/client/block.h
@@ -133,12 +133,6 @@ extern int64_t xdag_get_block_pos(const xdag_hash_t hash, xtime_t *time, struct 
 // return state info string
 extern const char* xdag_get_block_state_info(uint8_t flag);
 
-// returns a number of the current period, period is 64 seconds
-extern xtime_t xdag_main_time(void);
-
-// returns the number of the time period corresponding to the start of the network
-extern xtime_t xdag_start_main_time(void);
-
 // returns a number of key by hash of block or -1 if block is not ours
 extern int xdag_get_key(xdag_hash_t hash);
 

--- a/client/commands.c
+++ b/client/commands.c
@@ -832,7 +832,7 @@ int xfer_callback(void *data, xdag_hash_t hash, xdag_amount_t amount, xtime_t ti
 	if(!amount) {
 		return -1;
 	}
-	if(!g_is_miner && xdag_main_time() < (time >> 16) + 2 * CONFIRMATIONS_COUNT) {
+	if(!g_is_miner && xdag_get_frame() < (time >> 16) + 2 * CONFIRMATIONS_COUNT) {
 		return 0;
 	}
 	for(i = 0; i < xferData->keysCount; ++i) {
@@ -922,10 +922,10 @@ int out_balances()
 	struct out_balances_data d;
 	unsigned i = 0;
 	xdag_set_log_level(0);
-	xdag_mem_init((xdag_main_time() - xdag_start_main_time()) << 17);
+	xdag_mem_init((xdag_get_frame() - xdag_get_start_frame()) << 17);
 	xdag_crypt_init(0);
 	memset(&d, 0, sizeof(struct out_balances_data));
-	xdag_load_blocks(xdag_start_main_time() << 16, xdag_main_time() << 16, &i, &add_block_callback);
+	xdag_load_blocks(xdag_get_start_frame() << 16, xdag_get_frame() << 16, &i, &add_block_callback);
 	xdag_traverse_all_blocks(&d, out_balances_callback);
 	qsort(d.blocks, d.blocksCount, sizeof(struct xdag_field), out_sort_callback);
 	for(i = 0; i < d.blocksCount; ++i) {

--- a/client/init.h
+++ b/client/init.h
@@ -23,7 +23,7 @@ extern struct xdag_stats
 	uint32_t nhosts, total_nhosts;
 	union {
 		uint32_t reserved[2];
-		uint64_t main_time;
+		xdag_frame_t main_time;
 	};
 } g_xdag_stats;
 

--- a/client/miner.c
+++ b/client/miner.c
@@ -257,7 +257,7 @@ begin:
 					const uint64_t task_index = g_xdag_pool_task_index + 1;
 					struct xdag_pool_task *task = &g_xdag_pool_task[task_index & 1];
 
-					task->task_time = xdag_main_time();
+					task->task_time = xdag_get_frame();
 					xdag_hash_set_state(task->ctx, data[0].data,
 						sizeof(struct xdag_block) - 2 * sizeof(struct xdag_field));
 					xdag_hash_update(task->ctx, data[1].data, sizeof(struct xdag_field));

--- a/client/mining_common.h
+++ b/client/mining_common.h
@@ -14,7 +14,7 @@
 
 struct xdag_pool_task {
 	struct xdag_field task[2], lastfield, minhash, nonce;
-	xtime_t task_time;
+	xdag_frame_t task_time;
 	void *ctx0, *ctx;
 };
 

--- a/client/pool.c
+++ b/client/pool.c
@@ -267,7 +267,7 @@ void *general_mining_thread(void *arg)
 	xdag_mess("Starting main blocks creation...");
 
 	while(!g_stop_general_mining) {
-		xdag_create_and_send_block(0, 0, 0, 0, 0, xdag_main_time() << 16 | 0xffff, NULL);
+		xdag_create_and_send_block(0, 0, 0, 0, 0, xdag_get_frame() << 16 | 0xffff, NULL);
 	}
 
 	xdag_mess("Stopping general mining thread...");

--- a/client/storage.c
+++ b/client/storage.c
@@ -193,7 +193,7 @@ static int sort_callback(const void *l, const void *r)
 }
 
 /* Calls a callback for all blocks from the repository that are in specified time interval; returns the number of blocks */
-uint64_t xdag_load_blocks(xtime_t start_time, xtime_t end_time, void *data, void *(*callback)(void *, void *))
+uint64_t xdag_load_blocks(xdag_frame_t start_time, xdag_frame_t end_time, void *data, void *(*callback)(void *, void *))
 {
 	struct xdag_block *buf, *pbuf[bufsize];
 	struct xdag_storage_sum s;

--- a/client/storage.h
+++ b/client/storage.h
@@ -22,7 +22,7 @@ extern struct xdag_block *xdag_storage_load(xdag_hash_t hash, xtime_t time, uint
 	struct xdag_block *buf);
 
 /* Calls a callback for all blocks from the repository that are in specified time interval; returns the number of blocks */
-extern uint64_t xdag_load_blocks(xtime_t start_time, xtime_t end_time, void *data,
+extern uint64_t xdag_load_blocks(xdag_frame_t start_time, xdag_frame_t end_time, void *data,
 									  void *(*callback)(void *block, void *data));
 
 /* places the sums of blocks in 'sums' array, blocks are filtered by interval from start_time to end_time, splitted to 16 parts;

--- a/client/time.c
+++ b/client/time.c
@@ -9,13 +9,13 @@ xtime_t g_time_limit = DEF_TIME_LIMIT, g_xdag_era = XDAG_MAIN_ERA;
 extern int g_xdag_testnet;
 
 // returns a time period index, where a period is 64 seconds long
-xtime_t xdag_main_time(void)
+xdag_frame_t xdag_get_frame(void)
 {
 	return MAIN_TIME(xdag_get_xtimestamp());
 }
 
 // returns the time period index corresponding to the start of the network
-xtime_t xdag_start_main_time(void)
+xdag_frame_t xdag_get_start_frame(void)
 {
 	return MAIN_TIME(XDAG_ERA);
 }

--- a/client/time.h
+++ b/client/time.h
@@ -25,10 +25,10 @@ extern "C" {
 extern xtime_t g_xdag_era;
 
 // returns a time period index, where a period is 64 seconds long
-xtime_t xdag_main_time(void);
+xdag_frame_t xdag_get_frame(void);
 
 // returns the time period index corresponding to the start of the network
-xtime_t xdag_start_main_time(void);
+xdag_frame_t xdag_get_start_frame(void);
 
 // initialize time modeule
 int xdag_time_init(void);

--- a/client/transport.c
+++ b/client/transport.c
@@ -39,7 +39,7 @@ struct xdag_send_data {
 	void *connection;
 };
 
-#define add_main_timestamp(a)   ((a)->main_time = xdag_main_time())
+#define add_main_timestamp(a)   ((a)->main_time = xdag_get_frame())
 
 static void *xdag_send_thread(void *arg)
 {
@@ -65,8 +65,8 @@ static int process_transport_block(struct xdag_block *received_block, void *conn
 {
 	struct xdag_stats *stats = (struct xdag_stats *)&received_block->field[2];
 	struct xdag_stats *g = &g_xdag_stats;
-	xtime_t start_time = xdag_start_main_time();
-	xtime_t current_time = xdag_main_time();
+	xdag_frame_t start_time = xdag_get_start_frame();
+	xdag_frame_t current_time = xdag_get_frame();
 
 	if(current_time >= start_time && stats->total_nmain <= current_time - start_time + 1) {
 		if(stats->main_time <= current_time + 1) {

--- a/client/types.h
+++ b/client/types.h
@@ -4,5 +4,6 @@
 typedef uint64_t xdag_time_t;
 typedef xdag_time_t xtime_t;
 typedef uint64_t xdag_amount_t;
+typedef uint64_t xdag_frame_t;
 
 #endif


### PR DESCRIPTION
xdag_frame_t is basically the number of main block thus it isn't the same as xtime, it is called frame in the xdag whitepaper.