### PR TITLE
Update dfsrsa.c

### DIFF
--- a/dus/programs/dfstools/source/lib/dfsrsa.c
+++ b/dus/programs/dfstools/source/lib/dfsrsa.c
@@ -1001,6 +1001,8 @@ static int dfsrsa_isprime(dfsrsa_t *n, dfsrsa_t *work, int len)
 #endif
 			dfsrsa_debug(MILLER, "miller a", a, len);
 			dfsrsa_powmod(res, a, nm1, n, work, len);
+			if (*work == 1)
+				return 1;
 			dfsrsa_debug(MILLER, "miller a^(n-1)", res, len);
 			dfsrsa_debug(MILLER, "miller work", work, len);
 			dfsrsa_debug(MILLER, "miller work2", work2, len);


### PR DESCRIPTION
The value of "N" will not be changed when "work==1", but circulate meaninglessly, which leads to a much longer responding time of "Generating host keys".
In the function of the generated prime number, the value of "P" and "Q" in RSA algorithm will not be changed as long as work==1. 