### PR TITLE
enable tx remark

### DIFF
--- a/client/block.h
+++ b/client/block.h
@@ -52,7 +52,7 @@ enum bi_flags {
 
 #define XDAG_BLOCK_FIELDS 16
 
-#define REMARK_ENABLED 0
+#define REMARK_ENABLED 1
 
 #if CHAR_BIT != 8
 #error Your system hasn't exactly 8 bit for a char, it won't run.

--- a/client/init.c
+++ b/client/init.c
@@ -219,20 +219,20 @@ int parse_startup_parameters(int argc, char **argv, struct startup_parameters *p
 				printf("Number of transport threads is not given.\n");
 		} else if(ARG_EQUAL(argv[i], "", "-dm")) { /* disable mining */
 			g_disable_mining = 1;
-		//} else if(ARG_EQUAL(argv[i], "", "-tag")) { /* pool tag */
-		//	if(i + 1 < argc) {
-		//		if(validate_remark(argv[i + 1])) {
-		//			memcpy(g_pool_tag, argv[i + 1], strlen(argv[i + 1]));
-		//			g_pool_has_tag = 1;
-		//			++i;
-		//		} else {
-		//			printf("Pool tag exceeds 32 chars or is invalid ascii.\n");
-		//			return -1;
-		//		}
-		//	} else {
-		//		printUsage(argv[0]);
-		//		return -1;
-		//	}
+		} else if(ARG_EQUAL(argv[i], "", "-tag")) { /* pool tag */
+			if(i + 1 < argc) {
+				if(validate_remark(argv[i + 1])) {
+					memcpy(g_pool_tag, argv[i + 1], strlen(argv[i + 1]));
+					g_pool_has_tag = 1;
+					++i;
+				} else {
+					printf("Pool tag exceeds 32 chars or is invalid ascii.\n");
+					return -1;
+				}
+			} else {
+				printUsage(argv[0]);
+				return -1;
+			}
 		} else if(ARG_EQUAL(argv[i], "-l", "")) { /* list balance */
 			return out_balances();
 		} else {


### PR DESCRIPTION
* enable tx remark

tx remark is a new field in XDAG block to address the msg to be include in transactions. It's similar with memo in EOS network.
The max length of tx remark is 31 chars.