### PR TITLE
apollo fork height calibration

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -35,11 +35,14 @@
 #define MAX_WAITING_MAIN        1
 #define MAIN_START_AMOUNT       (1ll << 42)
 #define MAIN_APOLLO_AMOUNT      (1ll << 39)
-// nmain = 983201, at 2020-01-05 01:30:00 UTC
-//                 at 2020-01-05 09:30:00 UTC + 8
-#define MAIN_APOLLO_HEIGHT           983201
+// nmain = 964875, hash is xEMRhOnG2mntQRyi1T8ob/rqKKmRbxlV
+//                         at 2019-12-22 03:35:27 UTC
+//                         get this info from https://explorer.xdag.io/
+//
+// Apollo plans to upgrade on 2020-01-05 00:00:00 UTC
+//
+#define MAIN_APOLLO_HEIGHT           983573
 #define MAIN_APOLLO_TESTNET_HEIGHT   196250
-//#define MAIN_APOLLO_HIGHT       3  // for test
 #define MAIN_BIG_PERIOD_LOG     21
 #define MAX_LINKS               15
 #define MAKE_BLOCK_PERIOD       13


### PR DESCRIPTION
In order to ensure that the upgrade will be performed at 00:00:00 on January 5, 2020, the calibration upgrade height is 983573.

The calculation method is as follows:
1. select block
xEMRhOnG2mntQRyi1T8ob / rqKKmRbxlV

2. query block time
https://explorer.xdag.io/

MAIN BLOCKS: 964875
DATE AND TIME (UTC): 2019-12-22 03:35:27.999

3. fork height calculation 

between  2019-12-22 03:35:27 and  2020-01-05 00:00:00 
have 1196673 sec，1196673/64 == 18698

apollo fork height = 964875 + 18698 = 983573
