### PR TITLE
calibration apollo fork height 

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -35,13 +35,13 @@
 #define MAX_WAITING_MAIN        1
 #define MAIN_START_AMOUNT       (1ll << 42)
 #define MAIN_APOLLO_AMOUNT      (1ll << 39)
-// nmain = 964875, hash is xEMRhOnG2mntQRyi1T8ob/rqKKmRbxlV
-//                         at 2019-12-22 03:35:27 UTC
+// nmain = 976487, hash is WENN9ZgvXA+vNaslRLFQPgBKIbJVaMsu
+//                         at 2019-12-30 18:01:35 UTC
 //                         get this info from https://explorer.xdag.io/
 //
-// Apollo plans to upgrade on 2020-01-05 00:00:00 UTC
+// Apollo plans to upgrade on 2020-01-10 00:00:00 UTC
 //
-#define MAIN_APOLLO_HEIGHT           983573
+#define MAIN_APOLLO_HEIGHT           990323
 #define MAIN_APOLLO_TESTNET_HEIGHT   196250
 #define MAIN_BIG_PERIOD_LOG     21
 #define MAX_LINKS               15

--- a/client/block.c
+++ b/client/block.c
@@ -39,9 +39,9 @@
 //                         at 2019-12-30 18:01:35 UTC
 //                         get this info from https://explorer.xdag.io/
 //
-// Apollo plans to upgrade on 2020-01-10 00:00:00 UTC
+// Apollo plans to upgrade on 2020-01-30 00:00:00 UTC
 //
-#define MAIN_APOLLO_HEIGHT           990323
+#define MAIN_APOLLO_HEIGHT           1017323
 #define MAIN_APOLLO_TESTNET_HEIGHT   196250
 #define MAIN_BIG_PERIOD_LOG     21
 #define MAX_LINKS               15

--- a/client/block.c
+++ b/client/block.c
@@ -35,11 +35,14 @@
 #define MAX_WAITING_MAIN        1
 #define MAIN_START_AMOUNT       (1ll << 42)
 #define MAIN_APOLLO_AMOUNT      (1ll << 39)
-// nmain = 983201, at 2020-01-05 01:30:00 UTC
-//                 at 2020-01-05 09:30:00 UTC + 8
-#define MAIN_APOLLO_HEIGHT           983201
+// nmain = 964875, hash is xEMRhOnG2mntQRyi1T8ob/rqKKmRbxlV
+//                         at 2019-12-22 03:35:27 UTC
+//                         get this info from https://explorer.xdag.io/
+//
+// Apollo plans to upgrade on 2020-01-05 00:00:00 UTC
+//
+#define MAIN_APOLLO_HEIGHT           983573
 #define MAIN_APOLLO_TESTNET_HEIGHT   196250
-//#define MAIN_APOLLO_HIGHT       3  // for test
 #define MAIN_BIG_PERIOD_LOG     21
 #define MAX_LINKS               15
 #define MAKE_BLOCK_PERIOD       13


### PR DESCRIPTION
In order to ensure that the upgrade will be performed at 2020-01-30 00:00:00 UTC， after calibration upgrade height is 1017323.

The calculation method is as follows:

select block
WENN9ZgvXA+vNaslRLFQPgBKIbJVaMsu

query block time
https://explorer.xdag.io/

MAIN BLOCKS: 976487
DATE AND TIME (UTC): 2019-12-30 18:01:35 UTC

fork height calculation
between 2019-12-30 18:01:35 UTC and 2020-01-30 00:00:00 UTC
have 2613505 2613505/64 == 40836

apollo fork height = 976487 + 40836 = 1017323