### PR TITLE
Modify testnet parameters and fix reward problem

### DIFF
--- a/client/block.c
+++ b/client/block.c
@@ -361,9 +361,9 @@ static void set_main(struct block_internal *m)
 static void unset_main(struct block_internal *m)
 {
     xdag_amount_t amount = 0;
-	g_xdag_stats.nmain--;
 	g_xdag_stats.total_nmain--;
     amount = get_amount(g_xdag_stats.nmain);
+	g_xdag_stats.nmain--;
 	m->flags &= ~BI_MAIN;
 	accept_amount(m, (xdag_amount_t)0 - amount);
 	accept_amount(m, unapply_block(m));

--- a/client/rx_hash.h
+++ b/client/rx_hash.h
@@ -16,11 +16,11 @@
 #define SEEDHASH_EPOCH_BLOCKS   4096
 #define SEEDHASH_EPOCH_LAG      128 // lag time frames
 
-#define SEEDHASH_EPOCH_TESTNET_BLOCKS	64
-#define SEEDHASH_EPOCH_TESTNET_LAG		32
+#define SEEDHASH_EPOCH_TESTNET_BLOCKS	2048
+#define SEEDHASH_EPOCH_TESTNET_LAG		64
 
 #define RANDOMX_FORK_HEIGHT           1540096 // fork seed height, it's time frame + SEEDHASH_EPOCH_LAG = fork time frame
-#define RANDOMX_TESTNET_FORK_HEIGHT   196288 // 196288 % 64 = 0
+#define RANDOMX_TESTNET_FORK_HEIGHT   4096 // 196288 % 64 = 0
 
 typedef struct rx_pool_memory {
     xdag_hash_t seed;


### PR DESCRIPTION
Modify testnet randomX parameters,
SEEDHASH_EPOCH_TESTNET_BLOCKS change to 2048
SEEDHASH_EPOCH_TESTNET_LAG change to 64
RANDOMX_TESTNET_FORK_HEIGHT  change to 4096
And fix reward problem when the block unwind
